### PR TITLE
Add dynamic angle

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -126,8 +126,8 @@ Press T to toggle controls (K and L will still work)"
             // height_min: 10.0,
             // Increase max height (decrease min zoom)
             height_max: 50.0,
-            // Change the angle of the camera to 40 degrees
-            min_angle: 40.0f32.to_radians(),
+            // Change the angle of the camera to 35 degrees
+            min_angle: 35.0f32.to_radians(),
             // Decrease smoothing
             smoothness: 0.1,
             // Change starting position

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -123,17 +123,19 @@ Press T to toggle controls (K and L will still work)"
         Camera3dBundle::default(),
         RtsCamera {
             // Increase min height (decrease max zoom)
-            height_min: 10.0,
+            // height_min: 10.0,
             // Increase max height (decrease min zoom)
             height_max: 50.0,
-            // Change the angle of the camera to 10 degrees (0 is looking straight down)
-            angle: 10.0f32.to_radians(),
+            // Change the angle of the camera to 40 degrees
+            min_angle: 40.0f32.to_radians(),
             // Decrease smoothing
             smoothness: 0.1,
             // Change starting position
             target_focus: Transform::from_xyz(3.0, 0.0, -3.0),
             // Change starting zoom level
             target_zoom: 0.2,
+            // Disable dynamic angle (angle of camera will stay at `min_angle`)
+            // dynamic_angle: false,
             ..default()
         },
         RtsCameraControls {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub struct RtsCamera {
     /// The angle of the camera at no zoom (max height). By default, angle increases as you zoom in.
     /// If `dynamic_angle` is disabled, then that does not happen and the camera will stay fixed at
     /// `min_zoom`.
-    /// This is angle value you should change when adding this component.
+    /// If you want to customise the angle, this is what you want to change.
     /// Defaults to 25 degrees.
     pub min_angle: f32,
     /// Whether the camera should increase its angle the more you zoom in, so you can see

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,13 +84,13 @@ pub struct RtsCamera {
     pub height_max: f32,
     /// The current angle in radians of the camera, where a value of `0.0` is looking directly down
     /// (-Y), and a value of `TAU / 4.0` (90 degrees) is looking directly forward.
-    /// You probably don't want to set this manually, but rather set `min_angle`.
+    /// If you want to customise the angle, set `min_angle` instead.
     /// Defaults to 25 degrees.
     pub angle: f32,
     /// The target angle in radians of the camera, where a value of `0.0` is looking directly down
     /// (-Y), and a value of `TAU / 4.0` (90 degrees) is looking directly forward.
     /// The camera will smoothly transition from `angle` to `target_angle`.
-    /// You probably don't want to set this manually, but rather set `min_angle`.
+    /// If you want to customise the angle, set `min_angle` instead.
     /// Defaults to 25 degrees.
     pub target_angle: f32,
     /// The angle of the camera at no zoom (max height). By default, angle increases as you zoom in.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,13 @@
 
 use bevy::prelude::*;
 use bevy_mod_raycast::prelude::{IntersectionData, Raycast, RaycastSettings};
+use std::f32::consts::TAU;
 
 mod controller;
 use crate::controller::RtsCameraControlsPlugin;
 pub use controller::RtsCameraControls;
+
+const MAX_ANGLE: f32 = TAU / 5.0;
 
 /// Bevy plugin that provides RTS camera controls.
 /// # Example
@@ -31,6 +34,7 @@ impl Plugin for RtsCameraPlugin {
                 (
                     follow_ground,
                     snap_to_target,
+                    dynamic_angle,
                     move_towards_target,
                     update_camera_transform,
                 )
@@ -78,10 +82,28 @@ pub struct RtsCamera {
     /// The maximum height the camera can zoom out to, or the height of the camera at `0.0` zoom.
     /// Defaults to `10.0`.
     pub height_max: f32,
-    /// The angle in radians of the camera, where a value of `0.0` is looking directly down (-Y),
-    /// and a value of `TAU / 4.0` (90 degrees) is looking directly forward.
+    /// The current angle in radians of the camera, where a value of `0.0` is looking directly down
+    /// (-Y), and a value of `TAU / 4.0` (90 degrees) is looking directly forward.
+    /// You probably don't want to set this manually, but rather set `min_angle`.
     /// Defaults to 25 degrees.
     pub angle: f32,
+    /// The target angle in radians of the camera, where a value of `0.0` is looking directly down
+    /// (-Y), and a value of `TAU / 4.0` (90 degrees) is looking directly forward.
+    /// The camera will smoothly transition from `angle` to `target_angle`.
+    /// You probably don't want to set this manually, but rather set `min_angle`.
+    /// Defaults to 25 degrees.
+    pub target_angle: f32,
+    /// The angle of the camera at no zoom (max height). By default, angle increases as you zoom in.
+    /// If `dynamic_angle` is disabled, then that does not happen and the camera will stay fixed at
+    /// `min_zoom`.
+    /// This is angle value you should change when adding this component.
+    /// Defaults to 25 degrees.
+    pub min_angle: f32,
+    /// Whether the camera should increase its angle the more you zoom in, so you can see
+    /// characters up close from a sideways view instead of top down.
+    /// If this is
+    /// Defaults to `true`.
+    pub dynamic_angle: bool,
     /// The amount of smoothing applied to the camera movement. Should be a value between `0.0` and
     /// `1.0`. Set to `0.0` to disable smoothing. `1.0` is infinite smoothing (the camera won't
     /// move).
@@ -126,6 +148,9 @@ impl Default for RtsCamera {
             height_min: 2.0,
             height_max: 30.0,
             angle: 20.0f32.to_radians(),
+            target_angle: 20.0f32.to_radians(),
+            min_angle: 20.0f32.to_radians(),
+            dynamic_angle: true,
             smoothness: 0.3,
             focus: Transform::IDENTITY,
             target_focus: Transform::IDENTITY,
@@ -150,6 +175,8 @@ fn initialize(mut cam_q: Query<&mut RtsCamera, Added<RtsCamera>>) {
         cam.zoom = cam.target_zoom;
         cam.target_focus.translation.y = cam.height_max.lerp(cam.height_min, cam.zoom);
         cam.focus = cam.target_focus;
+        cam.angle = cam.min_angle;
+        cam.target_angle = cam.min_angle;
     }
 }
 
@@ -185,6 +212,12 @@ fn snap_to_target(mut cam_q: Query<&mut RtsCamera>) {
     }
 }
 
+fn dynamic_angle(mut query: Query<&mut RtsCamera>) {
+    for mut cam in query.iter_mut().filter(|cam| cam.dynamic_angle) {
+        cam.target_angle = cam.min_angle.lerp(MAX_ANGLE, ease_in_circular(cam.zoom));
+    }
+}
+
 fn move_towards_target(mut cam_q: Query<&mut RtsCamera>, time: Res<Time>) {
     for mut cam in cam_q.iter_mut() {
         cam.focus.translation = cam.focus.translation.lerp(
@@ -199,13 +232,22 @@ fn move_towards_target(mut cam_q: Query<&mut RtsCamera>, time: Res<Time>) {
             cam.target_zoom,
             1.0 - cam.smoothness.powi(7).powf(time.delta_seconds()),
         );
+        cam.angle = cam.target_angle.lerp(
+            cam.target_angle,
+            1.0 - cam.smoothness.powi(7).powf(time.delta_seconds()),
+        );
     }
 }
 
 fn update_camera_transform(mut cam_q: Query<(&mut Transform, &RtsCamera)>) {
     for (mut tfm, cam) in cam_q.iter_mut() {
         let rotation = Quat::from_rotation_x(cam.angle - 90f32.to_radians());
-        let camera_offset = (cam.height_max.lerp(cam.height_min, cam.zoom)) * cam.angle.tan();
+        let mut camera_offset = (cam.height_max.lerp(cam.height_min, cam.zoom)) * cam.angle.tan();
+        if cam.dynamic_angle {
+            // Subtract up to half of the offset, so the camera gets closer to the target
+            // without ending up sitting on top of it (i.e. to get a nice front view)
+            camera_offset *= 1.0 - ease_in_circular(cam.zoom).remap(0.0, 1.0, 0.0, 0.4);
+        }
         tfm.rotation = cam.focus.rotation * rotation;
         tfm.translation = cam.focus.translation + cam.focus.back() * camera_offset;
     }
@@ -226,4 +268,8 @@ fn cast_ray<'a>(
         },
     );
     hits1.first().map(|(_, hit)| hit)
+}
+
+fn ease_in_circular(x: f32) -> f32 {
+    1.0 - (1.0 - x.powi(2)).sqrt()
 }


### PR DESCRIPTION
Dynamically increase angle of camera the more you zoom in. Can be disabled. Max angle is hard coded, because as it approaches 90 degrees bad things happen.

`min_angle` is now the field that should be customised instead of `angle`. There is also a `target_angle` to support smoothing the angle changes. It's possible I could use the camera's transform instead of `angle`, but I didn't see much point.

The movement of the camera at max zoom is a bit weird (it moves back a little), and I'm not quite sure why, but I actually think it works well for the purpose.

![Screen Recording 2024-03-09 at 17 12 13](https://github.com/Plonq/bevy_rts_camera/assets/7709415/61977c40-7b2d-48d1-a86e-033d17fe446b)
