### PR TITLE
Fix link to the advanced example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ commands.spawn((
 This will set up a camera at world origin with good defaults based on a roughly realistic scale (where an average human
 is 1.75 units tall).
 
-Check out the [advanced example](https://github.com/Plonq/bevy_panorbit_camera/tree/master/examples/advanced.rs) to see
+Check out the [advanced example](https://github.com/Plonq/bevy_rts_camera/blob/main/examples/advanced.rs) to see
 the possible configuration options.
 
 ## Version Compatibility


### PR DESCRIPTION
Hi @Plonq! Thank you for sharing this plugin with the rest of us. I've noticed that the advanced example link in README was pointing to another of your excellent plugins, the Pan/Orbit Camera.