### PR TITLE
Derive the Reflect trait on the Ground component

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,8 @@ impl Default for RtsCamera {
 /// (based on min/max height and zoom) above any meshes marked with this component (using a ray
 /// cast).
 /// You'll likely want to mark all terrain entities, but not things like buildings, trees, or units.
-#[derive(Component, Copy, Clone, Debug, PartialEq)]
+#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
+#[reflect(Component)]
 pub struct Ground;
 
 fn initialize(mut cam_q: Query<&mut RtsCamera, Added<RtsCamera>>) {


### PR DESCRIPTION
This fixes https://github.com/Plonq/bevy_rts_camera/issues/7 by allowing to call `app.register_type::<Ground>()` in applications using this crate. Maybe this should even be done in the plugin setup? I'm not sure, so as a starting point I'm leaving it to application developers to register the type in their apps.

For context, this is required (?) in order to use scenes loaded from .glb (GLTF) files. If you would like that, I can probably make a simple example to demonstrate how to use RTS camera with GLTF assets.