### PR TITLE
Fix virtual time affecting camera speed

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -110,7 +110,7 @@ pub fn pan(
     button_input: Res<ButtonInput<KeyCode>>,
     mouse_input: Res<ButtonInput<MouseButton>>,
     primary_window_q: Query<&Window, With<PrimaryWindow>>,
-    time: Res<Time>,
+    time: Res<Time<Real>>,
 ) {
     for (mut cam, controller) in cam_q.iter_mut().filter(|(_, ctrl)| ctrl.enabled) {
         if controller

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ fn dynamic_angle(mut query: Query<&mut RtsCamera>) {
     }
 }
 
-fn move_towards_target(mut cam_q: Query<&mut RtsCamera>, time: Res<Time>) {
+fn move_towards_target(mut cam_q: Query<&mut RtsCamera>, time: Res<Time<Real>>) {
     for mut cam in cam_q.iter_mut() {
         cam.focus.translation = cam.focus.translation.lerp(
             cam.target_focus.translation,


### PR DESCRIPTION
Changing virtual time using `ResMut<Time<Virtual>>` should not affect camera pan speed