### PR TITLE
fixing README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ the possible configuration options.
 
 | bevy | bevy_rts_camera |
 |------|-----------------|
+| 0.14 | 0.8             |
 | 0.13 | 0.1-0.7         |
 
 ## License


### PR DESCRIPTION
version compatibility table in readme after bevy 0.14 / bevy_rts_camer 0.8 update