### PR TITLE
Leafwing input manager integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install alsa, udev and wayland
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - run: cargo build
 
   test:
@@ -54,5 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install alsa, udev and wayland
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - run: rustup component add clippy
       - run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = ["assets/"]
 
 [features]
-default = []
+default = ["controller"]
 controller = ["leafwing-input-manager"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_picking",
     "bevy_mesh_picking_backend",
 ] }
+leafwing-input-manager = { version = "0.17.0" }
 
 [dev-dependencies]
 bevy = { version = "0.16" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ homepage = "https://github.com/Plonq/bevy_rts_camera"
 readme = "README.md"
 exclude = ["assets/"]
 
+[features]
+default = []
+controller = ["leafwing-input-manager"]
+
 [dependencies]
 bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
@@ -20,7 +24,17 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_picking",
     "bevy_mesh_picking_backend",
 ] }
-leafwing-input-manager = { version = "0.17.0" }
+leafwing-input-manager = { version = "0.17.0", optional = true }
+
 
 [dev-dependencies]
 bevy = { version = "0.16" }
+leafwing-input-manager = { version = "0.17.0" }
+
+[[example]]
+name = "basic"
+required-features = ["controller"]
+
+[[example]]
+name = "advanced"
+required-features = ["controller"]

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ A minimal controller is included with these default controls:
 
 - Pan: Arrow Keys
 - Zoom: Mouse Wheel
-- Rotate: Middle Right + Drag
+- Rotate: Right Mouse + Drag
 
 `RtsCameraAction::minimal_input_map()`
-```rust
+```rust ignore
 InputMap::default()
     // Pan Action
     .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
@@ -57,7 +57,7 @@ A full controller is included with these default controls:
 - Rotate: Right Mouse + Drag, Key (R,F)
 - Grab: Middle Mouse + Drag
 
-```rust
+```rust ignore
 InputMap::default()
     // Pan Action
     .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
@@ -92,9 +92,10 @@ Add `RtsCamera` (this will automatically add a `Camera3d` but you can add it man
 ```rust ignore
 commands.spawn((
     RtsCamera::default(),
-    RtsCameraAction::minimal_input_map(), // Required, You can put a custom map
-    // RtsCameraAction::full_input_map(), // a full version of input map
-    RtsCameraControls::default(), // Required
+    RtsCameraControls::default(), // Optional
+    RtsCameraAction::minimal_input_map(), // Minimal Control, Use along with RtsCamera Control
+    // RtsCameraAction::full_input_map(), // Full Control
+    // You can put a custom leafwing_input_manager::InputMap
 ));
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A minimal controller is included with these default controls:
 
 - Pan: Arrow Keys
 - Zoom: Mouse Wheel
-- Rotate: Right Mouse + Drag
+- Rotate: Right Mouse + Left Mouse + Drag
 
 `RtsCameraAction::minimal_input_map()`
 ```rust ignore
@@ -43,8 +43,11 @@ InputMap::default()
     // Zoom Action
     .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
     // Rotate
-    .with(RtsCameraAction::RotateMode, MouseButton::Right)
-    .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+    .with(
+        RtsCameraAction::RotateMode,
+        ButtonlikeChord::new([MouseButton::Left, MouseButton::Right]),
+    )
+    .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
 ```
 
 
@@ -54,7 +57,7 @@ InputMap::default()
 A full controller is included with these default controls:
 - Pan: Arrow Keys, WASD, Game Pad Button
 - Zoom: Mouse Wheel, Key (E,Q)
-- Rotate: Right Mouse + Drag, Key (R,F)
+- Rotate: Right Mouse + Left Mouse + Drag, Key (R,F)
 - Grab: Middle Mouse + Drag
 
 ```rust ignore

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Add `RtsCamera` (this will automatically add a `Camera3d` but you can add it man
 commands.spawn((
     RtsCamera::default(),
     RtsCameraControls::default(), // Optional
-    RtsCameraAction::minimal_input_map(), // Minimal Control, Use along with RtsCamera Control
-    // RtsCameraAction::full_input_map(), // Full Control
-    // You can put a custom leafwing_input_manager::InputMap
+    RtsCameraAction::minimal_input_map(), // Minimal controls. Use along with `RtsCameraControls`
+    // RtsCameraAction::full_input_map(), // Full controls
+    // You can optionally use a custom `leafwing_input_manager::InputMap` instead
 ));
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ InputMap::default()
     )
     .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
     // Rotate
-    .with(RtsCameraAction::RotateMode, MouseButton::Right)
-    .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+    .with(
+        RtsCameraAction::RotateMode,
+        ButtonlikeChord::new([MouseButton::Left, MouseButton::Right]),
+    )
+    .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
     .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
     // Grab

--- a/README.md
+++ b/README.md
@@ -14,22 +14,70 @@ Bevy RTS Camera provides an RTS-style camera for Bevy Engine, to get your game u
 simple use cases, and does not try to cover advanced requirements.
 
 ## Features:
-
 - Pan, zoom, and rotation
 - Automatically follows whatever you mark as 'ground'
 - Smoothed movement
 - Customisable controls and other settings
 - Comes with optional controller, or you can control it yourself
+- Integrated with [leafwing-input-manager](https://github.com/Leafwing-Studios/leafwing-input-manager/tree/main)
 
 ## Default Controller
 
-A default controller is included with these default controls:
+You can 'edge pan' by moving the mouse to the edge of the screen.
 
-- Arrow Keys: pan
-- Mouse Wheel: zoom
-- Middle Mouse: rotate
 
-You can also 'edge pan' by moving the mouse to the edge of the screen.
+
+### Minimal Controller 
+
+A minimal controller is included with these default controls:
+
+- Pan: Arrow Keys
+- Zoom: Mouse Wheel
+- Rotate: Middle Right + Drag
+
+`RtsCameraAction::minimal_input_map()`
+```rust
+InputMap::default()
+    // Pan Action
+    .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
+    // Zoom Action
+    .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
+    // Rotate
+    .with(RtsCameraAction::RotateMode, MouseButton::Right)
+    .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+```
+
+
+### Full Controller
+`RtsCameraAction::full_input_map()`
+
+A full controller is included with these default controls:
+- Pan: Arrow Keys, WASD, Game Pad Button
+- Zoom: Mouse Wheel, Key (E,Q)
+- Rotate: Right Mouse + Drag, Key (R,F)
+- Grab: Middle Mouse + Drag
+
+```rust
+InputMap::default()
+    // Pan Action
+    .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
+    .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
+    .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::action_pad())
+    // Zoom Action
+    .with_axis(
+        RtsCameraAction::ZoomAxis,
+        VirtualAxis::new(KeyCode::KeyE, KeyCode::KeyQ),
+    )
+    .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
+    // Rotate
+    .with(RtsCameraAction::RotateMode, MouseButton::Right)
+    .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+    .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
+    .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
+    // Grab
+    .with(RtsCameraAction::GrabMode, MouseButton::Middle)
+    .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
+```
 
 ## Quick Start
 
@@ -44,7 +92,9 @@ Add `RtsCamera` (this will automatically add a `Camera3d` but you can add it man
 ```rust ignore
 commands.spawn((
     RtsCamera::default(),
-    RtsCameraControls::default(),  // Optional
+    RtsCameraAction::minimal_input_map(), // Required, You can put a custom map
+    // RtsCameraAction::full_input_map(), // a full version of input map
+    RtsCameraControls::default(), // Required
 ));
 ```
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -102,7 +102,7 @@ Press T to toggle controls (K and L will still work)",
     commands.spawn((
         RtsCamera {
             // Increase min height (decrease max zoom)
-            // height_min: 10.0,
+            height_min: 10.0,
             // Increase max height (decrease min zoom)
             height_max: 50.0,
             // Change the angle of the camera to 35 degrees
@@ -114,14 +114,12 @@ Press T to toggle controls (K and L will still work)",
             // Change starting zoom level
             target_zoom: 0.2,
             // Disable dynamic angle (angle of camera will stay at `min_angle`)
-            // dynamic_angle: false,
+            dynamic_angle: false,
             ..default()
         },
         RtsCameraControls {
             // Keep the mouse cursor in place when rotating
             lock_on_rotate: true,
-            // Drag pan with middle click
-            // button_drag: Some(MouseButton::Middle),
             // Keep the mouse cursor in place when dragging
             lock_on_drag: true,
             // Change the width of the area that triggers edge pan. 0.1 is 10% of the window height.
@@ -151,7 +149,7 @@ Press T to toggle controls (K and L will still work)",
             // Grab
             // Grab with Mouse
             .with(RtsCameraAction::GrabMode, MouseButton::Middle)
-            .with_dual_axis(RtsCameraAction::Grab, MouseMove::default()),
+            .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default()),
     ));
 }
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -142,7 +142,7 @@ Press T to toggle controls (K and L will still work)",
             // Rotate
             // Rotate with Mouse
             .with(RtsCameraAction::RotateMode, MouseButton::Right)
-            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
             // Rotate with Button
             .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
             .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -115,23 +115,14 @@ Press T to toggle controls (K and L will still work)",
             ..default()
         },
         RtsCameraControls {
-            // Change pan controls to WASD
-            key_up: KeyCode::KeyW,
-            key_down: KeyCode::KeyS,
-            key_left: KeyCode::KeyA,
-            key_right: KeyCode::KeyD,
-            // Rotate the camera with right click
-            button_rotate: MouseButton::Right,
             // Keep the mouse cursor in place when rotating
             lock_on_rotate: true,
             // Drag pan with middle click
-            button_drag: Some(MouseButton::Middle),
+            // button_drag: Some(MouseButton::Middle),
             // Keep the mouse cursor in place when dragging
             lock_on_drag: true,
             // Change the width of the area that triggers edge pan. 0.1 is 10% of the window height.
             edge_pan_width: 0.1,
-            // Increase pan speed
-            pan_speed: 25.0,
             ..default()
         },
     ));

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -5,7 +5,10 @@ use std::f32::consts::TAU;
 
 use bevy::prelude::*;
 
-use bevy_rts_camera::{Ground, RtsCamera, RtsCameraControls, RtsCameraPlugin, RtsCameraSystemSet};
+use bevy_rts_camera::{
+    Ground, RtsCamera, RtsCameraAction, RtsCameraControls, RtsCameraPlugin, RtsCameraSystemSet,
+};
+use leafwing_input_manager::prelude::*;
 
 fn main() {
     App::new()
@@ -125,6 +128,30 @@ Press T to toggle controls (K and L will still work)",
             edge_pan_width: 0.1,
             ..default()
         },
+        InputMap::default()
+            // Pan Action
+            // you can add multiple dual axis
+            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
+            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
+            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::action_pad())
+            // Zoom Action
+            // you can create your own axis
+            .with_axis(
+                RtsCameraAction::ZoomAxis,
+                VirtualAxis::new(KeyCode::KeyE, KeyCode::KeyQ),
+            )
+            .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
+            // Rotate
+            // Rotate with Mouse
+            .with(RtsCameraAction::RotateMode, MouseButton::Right)
+            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+            // Rotate with Button
+            .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
+            .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
+            // Grab
+            // Grab with Mouse
+            .with(RtsCameraAction::GrabMode, MouseButton::Middle)
+            .with_dual_axis(RtsCameraAction::Grab, MouseMove::default()),
     ));
 }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -73,6 +73,6 @@ fn setup(
     commands.spawn((
         RtsCamera::default(),
         RtsCameraControls::default(),
-        RtsCameraAction::default_input_map(),
+        RtsCameraAction::minimal_input_map(),
     ));
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,7 +3,7 @@
 
 use bevy::prelude::*;
 
-use bevy_rts_camera::{Ground, RtsCamera, RtsCameraControls, RtsCameraPlugin};
+use bevy_rts_camera::{Ground, RtsCamera, RtsCameraAction, RtsCameraControls, RtsCameraPlugin};
 
 fn main() {
     App::new()
@@ -70,5 +70,9 @@ fn setup(
         )),
     ));
     // Camera
-    commands.spawn((RtsCamera::default(), RtsCameraControls::default()));
+    commands.spawn((
+        RtsCamera::default(),
+        RtsCameraControls::default(),
+        RtsCameraAction::default_input_map(),
+    ));
 }

--- a/examples/custom_controller.rs
+++ b/examples/custom_controller.rs
@@ -1,0 +1,91 @@
+//! A basic scene with some "terrain" and "units"
+//! no bevy_rts_camera feature "controller"
+//! interface with RtsCamera Directly
+//! RTS camera.
+
+use bevy::prelude::*;
+
+use bevy_rts_camera::{Ground, RtsCamera, RtsCameraPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(RtsCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(80.0, 80.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+        // Add `Ground` component to any entity you want the camera to treat as ground.
+        Ground,
+    ));
+    // Some "terrain"
+    let terrain_material = materials.add(Color::srgb(0.8, 0.7, 0.6));
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(15.0, 1.0, 5.0))),
+        MeshMaterial3d(terrain_material.clone()),
+        Transform::from_xyz(15.0, 0.5, -5.0),
+        Ground,
+    ));
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(10.0, 5.0, 15.0))),
+        MeshMaterial3d(terrain_material.clone()),
+        Transform::from_xyz(-15.0, 2.5, 0.0),
+        Ground,
+    ));
+    commands.spawn((
+        Mesh3d(meshes.add(Sphere::new(12.5))),
+        MeshMaterial3d(terrain_material.clone()),
+        Transform::from_xyz(0.0, 0.0, -23.0),
+        Ground,
+    ));
+    // Some generic units that are not part of the 'Ground' (ignored for height calculation)
+    for x in -5..5 {
+        for z in -5..5 {
+            commands.spawn((
+                Mesh3d(meshes.add(Capsule3d::new(0.25, 1.25))),
+                MeshMaterial3d(terrain_material.clone()),
+                Transform::from_xyz(x as f32 * 0.7, 0.75, z as f32 * 0.7),
+            ));
+        }
+    }
+    // Light
+    commands.spawn((
+        DirectionalLight {
+            illuminance: 1000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_rotation(Quat::from_euler(
+            EulerRot::YXZ,
+            150.0f32.to_radians(),
+            -40.0f32.to_radians(),
+            0.0,
+        )),
+    ));
+    // Camera
+    commands.spawn((RtsCamera {
+        min_angle: (20.0_f32).to_radians(),
+        dynamic_angle: false,
+        ..default()
+    },));
+}
+
+fn update(mut rts_camera: Single<&mut RtsCamera>, time: Res<Time>) {
+    // You can directly modify the target with target_foucs
+    rts_camera.target_focus.rotate_y(1.0 * time.delta_secs());
+
+    // Control zooming
+    rts_camera.target_zoom = time.elapsed_secs().sin() / 2.0 + 0.5;
+
+    rts_camera.target_angle = (time.elapsed_secs().sin() * 20.0 + 45.0).to_radians()
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -260,7 +260,7 @@ pub fn pan(
         }
 
         if delta.length_squared() == 0.0 {
-            // // Edge pan
+            // Edge pan
             if let Ok(primary_window) = primary_window_q.single() {
                 if let Some(cursor_position) = primary_window.cursor_position() {
                     let win_w = primary_window.width();

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -86,7 +86,10 @@ impl RtsCameraAction {
     ///     // Zoom Action
     ///     .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
     ///     // Rotate
-    ///     .with(RtsCameraAction::RotateMode, MouseButton::Right)
+    ///     .with(
+    ///         RtsCameraAction::RotateMode,
+    ///         ButtonlikeChord::new([MouseButton::Left, MouseButton::Right]),
+    ///     )
     ///     .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     /// ```
     pub fn minimal_input_map() -> InputMap<RtsCameraAction> {
@@ -96,7 +99,10 @@ impl RtsCameraAction {
             // Zoom Action
             .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
             // Rotate
-            .with(RtsCameraAction::RotateMode, MouseButton::Right)
+            .with(
+                RtsCameraAction::RotateMode,
+                ButtonlikeChord::new([MouseButton::Left, MouseButton::Right]),
+            )
             .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     }
     /// A fully featured input map

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -113,7 +113,10 @@ impl RtsCameraAction {
     ///     )
     ///     .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
     ///     // Rotate
-    ///     .with(RtsCameraAction::RotateMode, MouseButton::Right)
+    ///     .with(
+    ///         RtsCameraAction::RotateMode,
+    ///         ButtonlikeChord::new([MouseButton::Left, MouseButton::Right]),
+    ///     )
     ///     .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     ///     .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
     ///     .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
@@ -134,7 +137,10 @@ impl RtsCameraAction {
             )
             .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
             // Rotate
-            .with(RtsCameraAction::RotateMode, MouseButton::Right)
+            .with(
+                RtsCameraAction::RotateMode,
+                ButtonlikeChord::new([MouseButton::Left, MouseButton::Right]),
+            )
             .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
             .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
             .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,12 +18,12 @@ impl Plugin for RtsCameraControlsPlugin {
     }
 }
 
-/// Define all possible action that a RtsCamera can perform.
+/// Define all possible action that a `RtsCamera` can perform.
 ///
 /// # used [leafwing-input-manager](https://github.com/Leafwing-Studios/leafwing-input-manager/tree/main)
 ///
 /// ## Modes
-/// There are three mode for the RtsCamera
+/// There are three mode for the `RtsCamera`
 /// - ### Normal Mode:
 ///     In normal mode, the user can use:
 ///     - `Pan` action to move the camera target on the XZ plane
@@ -35,7 +35,7 @@ impl Plugin for RtsCameraControlsPlugin {
 ///     
 ///     User can enter this mode by `RotateMode` action, a typical usage of this mode should be,
 ///     use a certain key to enter rotate mode, and some other axis to rotate
-///     ```rust
+///     ```no_run
 ///     InputMap::default()
 ///        .with(RtsCameraAction::RotateMode, MouseButton::Right)
 ///        .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
@@ -45,8 +45,8 @@ impl Plugin for RtsCameraControlsPlugin {
 ///     this is used for taking mouse action, but it can also use other axis input.
 ///     
 ///     User can enter this mode by `GrabMode` action, a typical usage of this mode should be,
-///     use a certain key to enter grab mode, and some other axis to rotate
-///     ```rust
+///     use a certain key to enter grab mode, and some other axis to move
+///     ```no_run
 ///     InputMap::default()
 ///         .with(RtsCameraAction::GrabMode, MouseButton::Middle)
 ///         .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
@@ -66,7 +66,7 @@ pub enum RtsCameraAction {
     /// `AxisLike` action for rotating around the camera's target in rotation mode
     #[actionlike(Axis)]
     RotateAxis,
-    /// `ButtonLike` action for rotating around  the camera's origin
+    /// `ButtonLike` action for rotating around the camera's origin
     Rotate(bool),
 
     // Grab
@@ -79,7 +79,7 @@ pub enum RtsCameraAction {
 
 impl RtsCameraAction {
     /// A minimal input map
-    /// ```rust
+    /// ```no_run
     /// InputMap::default()
     ///     // Pan Action
     ///     .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
@@ -87,7 +87,7 @@ impl RtsCameraAction {
     ///     .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
     ///     // Rotate
     ///     .with(RtsCameraAction::RotateMode, MouseButton::Right)
-    ///     .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+    ///     .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     /// ```
     pub fn minimal_input_map() -> InputMap<RtsCameraAction> {
         InputMap::default()
@@ -97,10 +97,10 @@ impl RtsCameraAction {
             .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
             // Rotate
             .with(RtsCameraAction::RotateMode, MouseButton::Right)
-            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     }
     /// A fully featured input map
-    /// ```rust
+    /// ```no_run
     /// InputMap::default()
     ///     // Pan Action
     ///     .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
@@ -114,7 +114,7 @@ impl RtsCameraAction {
     ///     .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
     ///     // Rotate
     ///     .with(RtsCameraAction::RotateMode, MouseButton::Right)
-    ///     .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+    ///     .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     ///     .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
     ///     .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
     ///     // Grab
@@ -135,7 +135,7 @@ impl RtsCameraAction {
             .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
             // Rotate
             .with(RtsCameraAction::RotateMode, MouseButton::Right)
-            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
             .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
             .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
             // Grab
@@ -422,14 +422,17 @@ pub fn rotate(
                 };
                 let value = axis_data.value / primary_window.width() * PI;
                 cam.target_focus.rotate_local_y(value);
-            } else if action_state.pressed(&RtsCameraAction::Rotate(true)) {
-                cam.target_focus.rotate_local_y(
-                    1.0 / primary_window.width() * PI * controller.key_rotate_speed,
-                );
-            } else if action_state.pressed(&RtsCameraAction::Rotate(false)) {
-                cam.target_focus.rotate_local_y(
-                    -1.0 / primary_window.width() * PI * controller.key_rotate_speed,
-                );
+            } else {
+                if action_state.pressed(&RtsCameraAction::Rotate(true)) {
+                    cam.target_focus.rotate_local_y(
+                        1.0 / primary_window.width() * PI * controller.key_rotate_speed,
+                    );
+                }
+                if action_state.pressed(&RtsCameraAction::Rotate(false)) {
+                    cam.target_focus.rotate_local_y(
+                        -1.0 / primary_window.width() * PI * controller.key_rotate_speed,
+                    );
+                }
             }
 
             if action_state.just_released(&RtsCameraAction::RotateMode) {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,20 +1,60 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::{Ground, RtsCamera, RtsCameraSystemSet};
-use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
-use bevy::input::ButtonInput;
 use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, PrimaryWindow};
+use leafwing_input_manager::prelude::*;
 use std::f32::consts::PI;
 
 pub struct RtsCameraControlsPlugin;
 
 impl Plugin for RtsCameraControlsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
-            Update,
-            (zoom, pan, grab_pan, rotate).before(RtsCameraSystemSet),
-        );
+        app.add_plugins(InputManagerPlugin::<RtsCameraAction>::default())
+            .add_systems(
+                Update,
+                (zoom, pan, grab_pan, rotate).before(RtsCameraSystemSet),
+            );
+    }
+}
+
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Hash, Reflect)]
+pub enum RtsCameraAction {
+    #[actionlike(DualAxis)]
+    Pan,
+    #[actionlike(Axis)]
+    Zoom,
+
+    // Rotate
+    RotateMode,
+    #[actionlike(Axis)]
+    Rotate,
+
+    // Grab
+    GrabMode,
+    #[actionlike(DualAxis)]
+    Grab,
+}
+
+impl RtsCameraAction {
+    pub fn default_input_map() -> InputMap<RtsCameraAction> {
+        InputMap::default()
+            // Pan Action
+            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
+            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
+            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::action_pad())
+            // Zoom Action
+            .with_axis(
+                RtsCameraAction::Zoom,
+                VirtualAxis::new(KeyCode::KeyE, KeyCode::KeyQ),
+            )
+            .with_axis(RtsCameraAction::Zoom, MouseScrollAxis::Y)
+            // Rotate
+            .with(RtsCameraAction::RotateMode, MouseButton::Right)
+            .with_axis(RtsCameraAction::Rotate, MouseMoveAxis::X)
+            // Grab
+            .with(RtsCameraAction::GrabMode, MouseButton::Middle)
+            .with_dual_axis(RtsCameraAction::Grab, MouseMove::default())
     }
 }
 
@@ -41,36 +81,12 @@ impl Plugin for RtsCameraControlsPlugin {
 /// ```
 #[derive(Component, Debug, PartialEq, Clone)]
 pub struct RtsCameraControls {
-    /// The key that will pan the camera up (or forward).
-    /// Defaults to `KeyCode::ArrowUp`.
-    pub key_up: KeyCode,
-    /// The key that will pan the camera down (or backward).
-    /// Defaults to `KeyCode::ArrowDown`.
-    pub key_down: KeyCode,
-    /// The key that will pan the camera left.
-    /// Defaults to `KeyCode::ArrowLeft`.
-    pub key_left: KeyCode,
-    /// The key that will pan the camera right.
-    /// Defaults to `KeyCode::ArrowRight`.
-    pub key_right: KeyCode,
-    /// The mouse button used to rotate the camera.
-    /// Defaults to `MouseButton::Middle`.
-    pub button_rotate: MouseButton,
-    /// The key that will rotate the camera left.
-    /// Defaults to `KeyCode::KeyQ`.
-    pub key_rotate_left: KeyCode,
-    /// The key that will rotate the camera right.
-    /// Defaults to `KeyCode::KeyE`.
-    pub key_rotate_right: KeyCode,
-    /// How fast the keys will rotate the camera.
-    /// Defaults to `16.0`.
-    pub key_rotate_speed: f32,
     /// Whether to lock the mouse cursor in place while rotating.
     /// Defaults to `false`.
     pub lock_on_rotate: bool,
-    /// The mouse button used to 'drag pan' the camera.
-    /// Defaults to `None`.
-    pub button_drag: Option<MouseButton>,
+    // /// The mouse button used to 'drag pan' the camera.
+    // /// Defaults to `None`.
+    // pub button_drag: Option<MouseButton>,
     /// Whether to lock the mouse cursor in place while dragging.
     /// Defaults to `false`.
     pub lock_on_drag: bool,
@@ -78,12 +94,6 @@ pub struct RtsCameraControls {
     /// of the window's height. Set to `0.0` to disable edge panning.
     /// Defaults to `0.05` (5%).
     pub edge_pan_width: f32,
-    /// Speed of camera pan (either via keyboard controls or edge panning).
-    /// Defaults to `15.0`.
-    pub pan_speed: f32,
-    /// How much the camera will zoom.
-    /// Defaults to `1.0`.
-    pub zoom_sensitivity: f32,
     /// Whether these controls are enabled.
     /// Defaults to `true`.
     pub enabled: bool,
@@ -92,105 +102,85 @@ pub struct RtsCameraControls {
 impl Default for RtsCameraControls {
     fn default() -> Self {
         RtsCameraControls {
-            key_up: KeyCode::ArrowUp,
-            key_down: KeyCode::ArrowDown,
-            key_left: KeyCode::ArrowLeft,
-            key_right: KeyCode::ArrowRight,
-            button_rotate: MouseButton::Middle,
-            key_rotate_left: KeyCode::KeyQ,
-            key_rotate_right: KeyCode::KeyE,
-            key_rotate_speed: 16.0,
             lock_on_rotate: false,
-            button_drag: None,
             lock_on_drag: false,
             edge_pan_width: 0.05,
-            pan_speed: 15.0,
-            zoom_sensitivity: 1.0,
             enabled: true,
         }
     }
 }
 
 pub fn zoom(
-    mut mouse_wheel: EventReader<MouseWheel>,
-    mut cam_q: Query<(&mut RtsCamera, &RtsCameraControls)>,
+    mut cam_q: Query<(
+        &mut RtsCamera,
+        &RtsCameraControls,
+        &ActionState<RtsCameraAction>,
+    )>,
 ) {
-    for (mut cam, cam_controls) in cam_q.iter_mut().filter(|(_, ctrl)| ctrl.enabled) {
-        let zoom_amount = mouse_wheel
-            .read()
-            .map(|event| match event.unit {
-                MouseScrollUnit::Line => event.y,
-                MouseScrollUnit::Pixel => event.y * 0.001,
-            })
-            .fold(0.0, |acc, val| acc + val);
-        let new_zoom =
-            (cam.target_zoom + zoom_amount * 0.5 * cam_controls.zoom_sensitivity).clamp(0.0, 1.0);
+    for (mut cam, cam_controls, action_state) in
+        cam_q.iter_mut().filter(|(_, ctrl, _)| ctrl.enabled)
+    {
+        let Some(axis_data) = action_state.axis_data(&RtsCameraAction::Zoom) else {
+            continue;
+        };
+        let zoom_amount = axis_data.value;
+        let new_zoom = (cam.target_zoom + zoom_amount * 0.5).clamp(0.0, 1.0);
         cam.target_zoom = new_zoom;
     }
 }
 
 pub fn pan(
-    mut cam_q: Query<(&mut RtsCamera, &RtsCameraControls)>,
-    button_input: Res<ButtonInput<KeyCode>>,
-    mouse_input: Res<ButtonInput<MouseButton>>,
+    mut cam_q: Query<(
+        &mut RtsCamera,
+        &RtsCameraControls,
+        &ActionState<RtsCameraAction>,
+    )>,
     primary_window_q: Query<&Window, With<PrimaryWindow>>,
     time: Res<Time<Real>>,
 ) {
-    for (mut cam, controller) in cam_q.iter_mut().filter(|(_, ctrl)| ctrl.enabled) {
-        if controller
-            .button_drag
-            .is_some_and(|btn| mouse_input.pressed(btn))
+    for (mut cam, controller, action_state) in cam_q.iter_mut().filter(|(_, ctrl, _)| ctrl.enabled)
+    {
+        if action_state.pressed(&RtsCameraAction::GrabMode)
+            | action_state.pressed(&RtsCameraAction::RotateMode)
         {
             continue;
         }
 
-        let mut delta = Vec3::ZERO;
+        let pan = action_state.axis_pair(&RtsCameraAction::Pan);
 
-        // Keyboard pan
-        if button_input.pressed(controller.key_up) {
-            delta += Vec3::from(cam.target_focus.forward())
-        }
-        if button_input.pressed(controller.key_down) {
-            delta += Vec3::from(cam.target_focus.back())
-        }
-        if button_input.pressed(controller.key_left) {
-            delta += Vec3::from(cam.target_focus.left())
-        }
-        if button_input.pressed(controller.key_right) {
-            delta += Vec3::from(cam.target_focus.right())
-        }
+        let delta = Vec3::from(cam.target_focus.forward()) * pan.y
+            + Vec3::from(cam.target_focus.left()) * -pan.x;
 
-        // Edge pan
-        if delta.length_squared() == 0.0 && !mouse_input.pressed(controller.button_rotate) {
-            if let Ok(primary_window) = primary_window_q.single() {
-                if let Some(cursor_position) = primary_window.cursor_position() {
-                    let win_w = primary_window.width();
-                    let win_h = primary_window.height();
-                    let pan_width = win_h * controller.edge_pan_width;
-                    // Pan left
-                    if cursor_position.x < pan_width {
-                        delta += Vec3::from(cam.target_focus.left())
-                    }
-                    // Pan right
-                    if cursor_position.x > win_w - pan_width {
-                        delta += Vec3::from(cam.target_focus.right())
-                    }
-                    // Pan up
-                    if cursor_position.y < pan_width {
-                        delta += Vec3::from(cam.target_focus.forward())
-                    }
-                    // Pan down
-                    if cursor_position.y > win_h - pan_width {
-                        delta += Vec3::from(cam.target_focus.back())
-                    }
-                }
-            }
-        }
+        // // Edge pan
+        // if delta.length_squared() == 0.0 && !mouse_input.pressed(controller.button_rotate) {
+        //     if let Ok(primary_window) = primary_window_q.single() {
+        //         if let Some(cursor_position) = primary_window.cursor_position() {
+        //             let win_w = primary_window.width();
+        //             let win_h = primary_window.height();
+        //             let pan_width = win_h * controller.edge_pan_width;
+        //             // Pan left
+        //             if cursor_position.x < pan_width {
+        //                 delta += Vec3::from(cam.target_focus.left())
+        //             }
+        //             // Pan right
+        //             if cursor_position.x > win_w - pan_width {
+        //                 delta += Vec3::from(cam.target_focus.right())
+        //             }
+        //             // Pan up
+        //             if cursor_position.y < pan_width {
+        //                 delta += Vec3::from(cam.target_focus.forward())
+        //             }
+        //             // Pan down
+        //             if cursor_position.y > win_h - pan_width {
+        //                 delta += Vec3::from(cam.target_focus.back())
+        //             }
+        //         }
+        //     }
+        // }
 
         let new_target = cam.target_focus.translation
             + delta.normalize_or_zero()
             * time.delta_secs()
-            * controller.pan_speed
             // Scale based on zoom so it (roughly) feels the same speed at different zoom levels
             * cam.target_zoom.remap(0.0, 1.0, 1.0, 0.5);
         cam.target_focus.translation = new_target;
@@ -205,27 +195,27 @@ pub fn grab_pan(
         &RtsCameraControls,
         &Camera,
         &Projection,
+        &ActionState<RtsCameraAction>,
     )>,
-    mut mouse_motion: EventReader<MouseMotion>,
-    mouse_button: Res<ButtonInput<MouseButton>>,
     mut ray_cast: MeshRayCast,
     mut ray_hit: Local<Option<Vec3>>,
     ground_q: Query<Entity, With<Ground>>,
     mut primary_window_q: Query<&mut Window, With<PrimaryWindow>>,
     mut previous_mouse_grab_mode: Local<CursorGrabMode>,
 ) {
-    for (cam_tfm, cam_gtfm, mut cam, controller, camera, projection) in cam_q
+    for (cam_tfm, cam_gtfm, mut cam, controller, camera, projection, action_state) in cam_q
         .iter_mut()
-        .filter(|(_, _, _, ctrl, _, _)| ctrl.enabled)
+        .filter(|(_, _, _, ctrl, _, _, _)| ctrl.enabled)
     {
-        let Some(drag_button) = controller.button_drag else {
+        if action_state.pressed(&RtsCameraAction::RotateMode) {
             continue;
-        };
+        }
+
         let Ok(mut primary_window) = primary_window_q.single_mut() else {
             return;
         };
 
-        if mouse_button.just_pressed(drag_button) && controller.lock_on_drag {
+        if action_state.just_pressed(&RtsCameraAction::GrabMode) && controller.lock_on_drag {
             let Some(cursor_position) = primary_window.cursor_position() else {
                 return;
             };
@@ -248,15 +238,15 @@ pub fn grab_pan(
             }
         }
 
-        if mouse_button.just_released(drag_button) {
+        if action_state.just_released(&RtsCameraAction::GrabMode) {
             *ray_hit = None;
 
             primary_window.cursor_options.grab_mode = *previous_mouse_grab_mode;
             primary_window.cursor_options.visible = true;
         }
 
-        if mouse_button.pressed(drag_button) {
-            let mut mouse_delta = mouse_motion.read().map(|e| e.delta).sum::<Vec2>();
+        if action_state.pressed(&RtsCameraAction::GrabMode) {
+            let mut mouse_delta = action_state.axis_pair(&RtsCameraAction::Grab);
 
             let mut multiplier = 1.0;
             let vp_size = camera.logical_viewport_size().unwrap();
@@ -283,48 +273,66 @@ pub fn grab_pan(
 }
 
 pub fn rotate(
-    mut cam_q: Query<(&mut RtsCamera, &RtsCameraControls)>,
-    mouse_input: Res<ButtonInput<MouseButton>>,
-    keys: Res<ButtonInput<KeyCode>>,
-    mut mouse_motion: EventReader<MouseMotion>,
+    mut cam_q: Query<(
+        &mut RtsCamera,
+        &RtsCameraControls,
+        &ActionState<RtsCameraAction>,
+    )>,
     mut primary_window_q: Query<&mut Window, With<PrimaryWindow>>,
     mut previous_mouse_grab_mode: Local<CursorGrabMode>,
 ) {
     if let Ok(mut primary_window) = primary_window_q.single_mut() {
-        for (mut cam, controller) in cam_q.iter_mut().filter(|(_, ctrl)| ctrl.enabled) {
-            if mouse_input.just_pressed(controller.button_rotate) && controller.lock_on_rotate {
+        for (mut cam, controller, action_state) in
+            cam_q.iter_mut().filter(|(_, ctrl, _)| ctrl.enabled)
+        {
+            if action_state.pressed(&RtsCameraAction::GrabMode) {
+                continue;
+            }
+
+            if action_state.just_pressed(&RtsCameraAction::RotateMode) && controller.lock_on_rotate
+            {
                 *previous_mouse_grab_mode = primary_window.cursor_options.grab_mode;
                 primary_window.cursor_options.grab_mode = CursorGrabMode::Locked;
                 primary_window.cursor_options.visible = false;
             }
 
-            if mouse_input.pressed(controller.button_rotate) {
-                let mouse_delta = mouse_motion.read().map(|e| e.delta).sum::<Vec2>();
-                // Adjust based on window size, so that moving mouse entire width of window
-                // will be one half rotation (180 degrees)
-                let delta_x = mouse_delta.x / primary_window.width() * PI;
-                cam.target_focus.rotate_local_y(-delta_x);
-            } else {
-                let left = if keys.pressed(controller.key_rotate_left) {
-                    1.0
-                } else {
-                    0.0
-                };
-                let right = if keys.pressed(controller.key_rotate_right) {
-                    1.0
-                } else {
-                    0.0
+            if action_state.pressed(&RtsCameraAction::RotateMode) {
+                let Some(axis_data) = action_state.axis_data(&RtsCameraAction::Rotate) else {
+                    continue;
                 };
 
-                let delta = right - left;
-                if delta != 0.0 {
-                    cam.target_focus.rotate_local_y(
-                        delta / primary_window.width() * PI * controller.key_rotate_speed,
-                    );
-                }
+                let value = axis_data.value / primary_window.width() * PI;
+
+                cam.target_focus.rotate_local_y(value);
             }
 
-            if mouse_input.just_released(controller.button_rotate) {
+            // if mouse_input.pressed(controller.button_rotate) {
+            //     let mouse_delta = mouse_motion.read().map(|e| e.delta).sum::<Vec2>();
+            //     // Adjust based on window size, so that moving mouse entire width of window
+            //     // will be one half rotation (180 degrees)
+            //     let delta_x = mouse_delta.x / primary_window.width() * PI;
+            //     cam.target_focus.rotate_local_y(-delta_x);
+            // } else {
+            //     let left = if keys.pressed(controller.key_rotate_left) {
+            //         1.0
+            //     } else {
+            //         0.0
+            //     };
+            //     let right = if keys.pressed(controller.key_rotate_right) {
+            //         1.0
+            //     } else {
+            //         0.0
+            //     };
+
+            //     let delta = right - left;
+            //     if delta != 0.0 {
+            //         cam.target_focus.rotate_local_y(
+            //             delta / primary_window.width() * PI * controller.key_rotate_speed,
+            //         );
+            //     }
+            // }
+
+            if action_state.just_released(&RtsCameraAction::RotateMode) {
                 primary_window.cursor_options.grab_mode = *previous_mouse_grab_mode;
                 primary_window.cursor_options.visible = true;
             }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -6,6 +6,7 @@ use bevy::window::{CursorGrabMode, CursorOptions, PrimaryWindow};
 use leafwing_input_manager::prelude::*;
 use std::f32::consts::PI;
 
+/// Bevy plugin that provide input handling for RTS camera control
 pub struct RtsCameraControlsPlugin;
 
 impl Plugin for RtsCameraControlsPlugin {
@@ -25,32 +26,32 @@ impl Plugin for RtsCameraControlsPlugin {
 /// ## Modes
 /// There are three mode for the `RtsCamera`
 /// - ### Normal Mode:
-///     In normal mode, the user can use:
-///     - `Pan` action to move the camera target on the XZ plane
-///     - `ZoomAxis` action to zoom near and far to the camera target
-///     - `Rotate(bool)` action to rotate orbit around the target.(`bool` specify rotation direction)
+///   In normal mode, the user can use:
+///   - `Pan` action to move the camera target on the XZ plane
+///   - `ZoomAxis` action to zoom near and far to the camera target
+///   - `Rotate(bool)` action to rotate orbit around the target.(`bool` specify rotation direction)
 /// - ### Rotate Mode:
-///     In rotate mode, user can send an `Axislike` `RotationAxis` to rotate the camera around target,
-///     this is used for taking mouse action, but it can also use other axis input.
+///   In rotate mode, user can send an `Axislike` `RotationAxis` to rotate the camera around target,
+///   this is used for taking mouse action, but it can also use other axis input.
 ///     
-///     User can enter this mode by `RotateMode` action, a typical usage of this mode should be,
-///     use a certain key to enter rotate mode, and some other axis to rotate
-///     ```ignore
-///     InputMap::default()
-///        .with(RtsCameraAction::RotateMode, MouseButton::Right)
-///        .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
-///     ```
+///   User can enter this mode by `RotateMode` action, a typical usage of this mode should be,
+///   use a certain key to enter rotate mode, and some other axis to rotate
+///   ```ignore
+///   InputMap::default()
+///      .with(RtsCameraAction::RotateMode, MouseButton::Right)
+///      .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
+///   ```
 /// - ### Grab Mode:
-///     Like in rotate mode, in Grab Mode, user can send an `DualAxislike` `GrabAxis` to grab move the camera,
-///     this is used for taking mouse action, but it can also use other axis input.
-///     
-///     User can enter this mode by `GrabMode` action, a typical usage of this mode should be,
-///     use a certain key to enter grab mode, and some other axis to move
-///     ```ignore
-///     InputMap::default()
-///         .with(RtsCameraAction::GrabMode, MouseButton::Middle)
-///         .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
-///     ```
+///   Like in rotate mode, in Grab Mode, user can send an `DualAxislike` `GrabAxis` to grab move the camera,
+///   this is used for taking mouse action, but it can also use other axis input.
+///   
+///   User can enter this mode by `GrabMode` action, a typical usage of this mode should be,
+///   use a certain key to enter grab mode, and some other axis to move
+///   ```ignore
+///   InputMap::default()
+///       .with(RtsCameraAction::GrabMode, MouseButton::Middle)
+///       .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
+///   ```
 #[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum RtsCameraAction {
     /// `DualAxisLike` action for XZ plane movement
@@ -332,6 +333,7 @@ pub fn pan(
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn grab_pan(
     mut cam_q: Query<(
         &Transform,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -35,7 +35,7 @@ impl Plugin for RtsCameraControlsPlugin {
 ///     
 ///     User can enter this mode by `RotateMode` action, a typical usage of this mode should be,
 ///     use a certain key to enter rotate mode, and some other axis to rotate
-///     ```no_run
+///     ```ignore
 ///     InputMap::default()
 ///        .with(RtsCameraAction::RotateMode, MouseButton::Right)
 ///        .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
@@ -46,7 +46,7 @@ impl Plugin for RtsCameraControlsPlugin {
 ///     
 ///     User can enter this mode by `GrabMode` action, a typical usage of this mode should be,
 ///     use a certain key to enter grab mode, and some other axis to move
-///     ```no_run
+///     ```ignore
 ///     InputMap::default()
 ///         .with(RtsCameraAction::GrabMode, MouseButton::Middle)
 ///         .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
@@ -79,7 +79,7 @@ pub enum RtsCameraAction {
 
 impl RtsCameraAction {
     /// A minimal input map
-    /// ```no_run
+    /// ```ignore
     /// InputMap::default()
     ///     // Pan Action
     ///     .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
@@ -106,7 +106,7 @@ impl RtsCameraAction {
             .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X.inverted())
     }
     /// A fully featured input map
-    /// ```no_run
+    /// ```ignore
     /// InputMap::default()
     ///     // Pan Action
     ///     .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
@@ -159,7 +159,7 @@ impl RtsCameraAction {
 /// Optional camera controller. If you want to use an input manager, don't use this and instead
 /// control the camera yourself by updating `RtsCamera.target_focus` and `RtsCamera.target_zoom`.
 /// # Example
-/// ```no_run
+/// ```ignore
 /// # use bevy::prelude::*;
 /// # use bevy_rts_camera::{RtsCameraPlugin, RtsCamera, RtsCameraControls};
 /// # fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@ use bevy::math::bounding::Aabb2d;
 use bevy::picking::mesh_picking::ray_cast::RayMeshHit;
 use bevy::prelude::*;
 
-use leafwing_input_manager::prelude::*;
-
 pub use controller::*;
 
 use crate::controller::RtsCameraControlsPlugin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@ use bevy::math::bounding::Aabb2d;
 use bevy::picking::mesh_picking::ray_cast::RayMeshHit;
 use bevy::prelude::*;
 
-pub use controller::RtsCameraControls;
+use leafwing_input_manager::prelude::*;
+
+pub use controller::*;
 
 use crate::controller::RtsCameraControlsPlugin;
 
@@ -32,6 +34,7 @@ pub struct RtsCameraPlugin;
 impl Plugin for RtsCameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(RtsCameraControlsPlugin)
+            // .add_plugins(InputManagerPlugin::<RtsCameraAction>::default())
             .add_systems(PreUpdate, initialize)
             .add_systems(
                 Update,
@@ -76,7 +79,7 @@ pub struct RtsCameraSystemSet;
 ///         ));
 ///  }
 /// ```
-#[derive(Component, Copy, Clone, Debug)]
+#[derive(Component, Clone, Debug)]
 #[require(Camera3d)]
 pub struct RtsCamera {
     /// The minimum height the camera can zoom in to, or the height of the camera at `1.0` zoom.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,11 @@ use bevy::math::bounding::Aabb2d;
 use bevy::picking::mesh_picking::ray_cast::RayMeshHit;
 use bevy::prelude::*;
 
-pub use controller::*;
-
+#[cfg(feature = "controller")]
 mod controller;
+
+#[cfg(feature = "controller")]
+pub use controller::*;
 
 const MAX_ANGLE: f32 = TAU / 5.0;
 
@@ -29,21 +31,21 @@ pub struct RtsCameraPlugin;
 
 impl Plugin for RtsCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(RtsCameraControlsPlugin)
-            .add_systems(PreUpdate, initialize)
-            .add_systems(
-                Update,
-                (
-                    follow_ground,
-                    snap_to_target,
-                    dynamic_angle,
-                    move_towards_target,
-                    apply_camera_bounds,
-                    update_camera_transform,
-                )
-                    .chain()
-                    .in_set(RtsCameraSystemSet),
-            );
+        #[cfg(feature = "controller")]
+        app.add_plugins(RtsCameraControlsPlugin);
+        app.add_systems(PreUpdate, initialize).add_systems(
+            Update,
+            (
+                follow_ground,
+                snap_to_target,
+                dynamic_angle,
+                move_towards_target,
+                apply_camera_bounds,
+                update_camera_transform,
+            )
+                .chain()
+                .in_set(RtsCameraSystemSet),
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@ use bevy::prelude::*;
 
 pub use controller::*;
 
-use crate::controller::RtsCameraControlsPlugin;
-
 mod controller;
 
 const MAX_ANGLE: f32 = TAU / 5.0;
@@ -32,7 +30,6 @@ pub struct RtsCameraPlugin;
 impl Plugin for RtsCameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(RtsCameraControlsPlugin)
-            // .add_plugins(InputManagerPlugin::<RtsCameraAction>::default())
             .add_systems(PreUpdate, initialize)
             .add_systems(
                 Update,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 mod controller;
 
 #[cfg(feature = "controller")]
-pub use controller::*;
+pub use controller::{RtsCameraAction, RtsCameraControls};
 
 const MAX_ANGLE: f32 = TAU / 5.0;
 
@@ -32,7 +32,7 @@ pub struct RtsCameraPlugin;
 impl Plugin for RtsCameraPlugin {
     fn build(&self, app: &mut App) {
         #[cfg(feature = "controller")]
-        app.add_plugins(RtsCameraControlsPlugin);
+        app.add_plugins(controller::RtsCameraControlsPlugin);
         app.add_systems(PreUpdate, initialize).add_systems(
             Update,
             (


### PR DESCRIPTION
I proposal to use [`leafwing-input-manager`](https://github.com/Leafwing-Studios/leafwing-input-manager/tree/main) to help customize input manager:
- it can allow multiple keybind
- seralize/deserialize able
-

## API
```rust ignore
commands.spawn((
    RtsCamera::default(),
    RtsCameraAction::minimal_input_map(), // Required, You can put a custom map
    // RtsCameraAction::full_input_map(), // a full version of input map
    RtsCameraControls::default(), // Required
));
```


## Added `RtsCameraAction`
leafwing required a action data structure as intermediary to handle inputs
```rust ignore
#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Hash, Reflect)]
pub enum RtsCameraAction {
    /// `DualAxisLike` action for XZ plane movement
    #[actionlike(DualAxis)]
    Pan,
    /// `AxisLike` action for zooming
    #[actionlike(Axis)]
    ZoomAxis,

    // Rotate
    /// `ButtonLike` action for entering rotate mode
    RotateMode,
    /// `AxisLike` action for rotating around the camera's target in rotation mode
    #[actionlike(Axis)]
    RotateAxis,
    /// `ButtonLike` action for rotating around the camera's origin
    Rotate(bool),

    // Grab
    /// `ButtonLike` action for entering grab mode
    GrabMode,
    /// `DualAxisLike` action for moving camera by grabbing point in ground
    #[actionlike(DualAxis)]
    GrabAxis,
}
```

Define all possible action that a `RtsCamera` can perform, used leafwing-input-manager.
### Modes
There are three mode for the `RtsCamera`
- ### Normal Mode:
    In normal mode, the user can use:
    - `Pan` action to move the camera target on the XZ plane
    - `ZoomAxis` action to zoom near and far to the camera target
    - `Rotate(bool)` action to rotate orbit around the target.(`bool` specify rotation direction)
- ### Rotate Mode:
    In rotate mode, user can send an `Axislike` `RotationAxis` to rotate the camera around target,
    this is used for taking mouse action, but it can also use other axis input.
    
    User can enter this mode by `RotateMode` action, a typical usage of this mode should be,
    use a certain key to enter rotate mode, and some other axis to rotate
    ```rust ignore
    InputMap::default()
       .with(RtsCameraAction::RotateMode, MouseButton::Right)
       .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
    ```
- ### Grab Mode:
    Like in rotate mode, in Grab Mode, user can send an `DualAxislike` `GrabAxis` to grab move the camera,
    this is used for taking mouse action, but it can also use other axis input.
    
    User can enter this mode by `GrabMode` action, a typical usage of this mode should be,
    use a certain key to enter grab mode, and some other axis to move
    ```rust ignore
    InputMap::default()
        .with(RtsCameraAction::GrabMode, MouseButton::Middle)
        .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
    ```

## Default input map
You can still 'edge pan' by moving the mouse to the edge of the screen.
### Minimal Controller 
A minimal controller is included with these default controls:
- Pan: Arrow Keys
- Zoom: Mouse Wheel
- Rotate: Middle Right + Drag

### Full Controller
A full controller is included with these default controls:
- Pan: Arrow Keys, WASD, Game Pad Button
- Zoom: Mouse Wheel, Key (E,Q)
- Rotate: Right Mouse + Drag, Key (R,F)
- Grab: Middle Mouse + Drag


```rust ignore
impl RtsCameraAction {
    /// A minimal input map
    pub fn minimal_input_map() -> InputMap<RtsCameraAction> {
        InputMap::default()
            // Pan Action
            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
            // Zoom Action
            .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
            // Rotate
            .with(RtsCameraAction::RotateMode, MouseButton::Right)
            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
    }
    /// A fully featured input map
    pub fn full_input_map() -> InputMap<RtsCameraAction> {
        InputMap::default()
            // Pan Action
            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::wasd())
            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::arrow_keys())
            .with_dual_axis(RtsCameraAction::Pan, VirtualDPad::action_pad())
            // Zoom Action
            .with_axis(
                RtsCameraAction::ZoomAxis,
                VirtualAxis::new(KeyCode::KeyE, KeyCode::KeyQ),
            )
            .with_axis(RtsCameraAction::ZoomAxis, MouseScrollAxis::Y)
            // Rotate
            .with(RtsCameraAction::RotateMode, MouseButton::Right)
            .with_axis(RtsCameraAction::RotateAxis, MouseMoveAxis::X)
            .with(RtsCameraAction::Rotate(true), KeyCode::KeyR)
            .with(RtsCameraAction::Rotate(false), KeyCode::KeyF)
            // Grab
            .with(RtsCameraAction::GrabMode, MouseButton::Middle)
            .with_dual_axis(RtsCameraAction::GrabAxis, MouseMove::default())
    }
}
```